### PR TITLE
Slim down image by not persisting the distribution zip in a layer.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,11 @@ WORKDIR /tmp
 
 RUN curl -fsSL "http://maven.ontotext.com/content/groups/all-onto/com/ontotext/graphdb/graphdb-${edition}/${version}/graphdb-${edition}-${version}-dist.zip" > \
     graphdb-${edition}-${version}.zip && \
-    bash -c 'md5sum -c - <<<"$(curl -fsSL http://maven.ontotext.com/content/groups/all-onto/com/ontotext/graphdb/graphdb-${edition}/${version}/graphdb-${edition}-${version}-dist.zip.md5) graphdb-${edition}-${version}.zip"'
-
-RUN mkdir -p ${GRAPHDB_PARENT_DIR} && \
+    bash -c 'md5sum -c - <<<"$(curl -fsSL http://maven.ontotext.com/content/groups/all-onto/com/ontotext/graphdb/graphdb-${edition}/${version}/graphdb-${edition}-${version}-dist.zip.md5) graphdb-${edition}-${version}.zip"' && \
+    mkdir -p ${GRAPHDB_PARENT_DIR} && \
     cd ${GRAPHDB_PARENT_DIR} && \
     unzip /tmp/graphdb-${edition}-${version}.zip && \
+    rm /tmp/graphdb-${edition}-${version}.zip && \
     mv graphdb-${edition}-${version} dist && \
     mkdir -p ${GRAPHDB_HOME}
 

--- a/free-edition/Dockerfile
+++ b/free-edition/Dockerfile
@@ -14,6 +14,7 @@ ADD graphdb-free-${version}-dist.zip /tmp
 RUN mkdir -p ${GRAPHDB_PARENT_DIR} && \
     cd ${GRAPHDB_PARENT_DIR} && \
     unzip /tmp/graphdb-free-${version}-dist.zip && \
+    rm /tmp/graphdb-free-${version}-dist.zip && \
     mv graphdb-${edition}-${version} dist && \
     mkdir -p ${GRAPHDB_HOME}
 


### PR DESCRIPTION
The current Dockerfile persists the GraphDB zip in /tmp, thus adding 130mb or so to the final image.

The problem:
```sh
$ docker run --rm -ti --entrypoint /bin/bash ontotext/graphdb:8.0.6-ee -c 'ls -lh /tmp'
total 126M
-rw-r--r-- 2 root root 126M Apr  4 14:27 graphdb-ee-8.0.6.zip
drwxr-xr-x 2 root root 4.0K Mar 21 22:49 hsperfdata_root
```

Before this PR:
```sh
$ docker images | grep ontotext | sed -E -e 's/  +/\t/g'
ontotext/graphdb	v8.0.6-ee-ontotext	2d28e3379b17	About an hour ago	930 MB
```

After this PR:
```sh
$ docker images | grep ontotext | sed -E -e 's/  +/\t/g'
ontotext/graphdb	8.0.6-ee	6db0597d06ab	5 minutes ago	799 MB
```