### PR TITLE
Removed zip and unzip because of a bug in the package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV GRAPHDB_INSTALL_DIR=${GRAPHDB_PARENT_DIR}/dist
 
 WORKDIR /tmp
 
-RUN apk add --no-cache unzip bash util-linux curl bind-tools procps net-tools busybox-extras wget curl zip screen vim less && \
+RUN apk add --no-cache bash util-linux curl bind-tools procps net-tools busybox-extras wget screen vim less && \
     curl -fsSL "http://maven.ontotext.com/content/groups/all-onto/com/ontotext/graphdb/graphdb-${edition}/${version}/graphdb-${edition}-${version}-dist.zip" > \
     graphdb-${edition}-${version}.zip && \
     bash -c 'md5sum -c - <<<"$(curl -fsSL http://maven.ontotext.com/content/groups/all-onto/com/ontotext/graphdb/graphdb-${edition}/${version}/graphdb-${edition}-${version}-dist.zip.md5)  graphdb-${edition}-${version}.zip"' && \

--- a/free-edition/Dockerfile
+++ b/free-edition/Dockerfile
@@ -11,7 +11,7 @@ ENV GRAPHDB_INSTALL_DIR=${GRAPHDB_PARENT_DIR}/dist
 
 ADD graphdb-free-${version}-dist.zip /tmp
 
-RUN apk add --no-cache unzip bash util-linux curl bind-tools procps net-tools busybox-extras wget curl zip screen vim less && \
+RUN apk add --no-cache bash util-linux curl bind-tools procps net-tools busybox-extras wget screen vim less && \
     mkdir -p ${GRAPHDB_PARENT_DIR} && \
     cd ${GRAPHDB_PARENT_DIR} && \
     unzip /tmp/graphdb-free-${version}-dist.zip && \


### PR DESCRIPTION
 Removed zip and unzip because of a bug in the package preventing unzipping GraphDB. Alpine has its own unzip which works