### PR TITLE
fix: Use importrdf preload

### DIFF
--- a/preload/docker-compose.yml
+++ b/preload/docker-compose.yml
@@ -11,10 +11,10 @@ services:
         version: ${GRAPHDB_VERSION}
 
     # Load all files from ../import in repo defined in ./graphdb-repo-config.ttl
-    entrypoint: [ "/opt/graphdb/dist/bin/preload", "--force", "--recursive", "-q", "/tmp", "-c", "/opt/graphdb/graphdb-repo-config.ttl", "/opt/graphdb/home/graphdb-import" ]
+    entrypoint: [ "/opt/graphdb/dist/bin/importrdf", "preload", "--force", "--recursive", "-q", "/tmp", "-c", "/opt/graphdb/graphdb-repo-config.ttl", "/opt/graphdb/home/graphdb-import" ]
 
     # Preload given file to existing repository (here "demo")
-    # entrypoint: [ "/opt/graphdb/dist/bin/preload", "-f", "-i", "demo", "/root/graphdb-import" ]
+    # entrypoint: [ "/opt/graphdb/dist/bin/importrdf", "preload", "-f", "-i", "demo", "/root/graphdb-import" ]
 
     environment: 
       GDB_JAVA_OPTS: >-


### PR DESCRIPTION
The old preload tool is baked in to importrdf as a parameter. Updating the docker-compose to reflect the changes.