### PR TITLE
Set platform in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ docker run -d -p 7200:7200 ontotext/graphdb:10.0.0
 
 Consult the docker hub documentation for more information.
 
+### Using docker compose
+
+```bash
+docker compose build
+```
+
+You can also specify the version of GraphDB you want to use with the `GRAPHDB_VERSION` [environment variable](https://docs.docker.com/compose/environment-variables/set-environment-variables/):
+```bash
+GRAPHDB_VERSION=10.1.3 docker compose build
+```
+
 ### Preload a repository
 
 Go to the `preload` folder to run the bulk load data when GraphDB is stopped.
@@ -76,6 +87,8 @@ docker-compose up -d
 > It will use the repo created by the preload in `graphdb-data/`
 
 > Feel free to add a `.env` file similar to the preload repository to define variables.
+
+Open GraphDB Workbench in your browser at `http://localhost:7200/`.
 
 
 # Issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        version: 10.0.0
+        version: ${GRAPHDB_VERSION-10.0.0}
     restart: unless-stopped
+    platform: linux/amd64
     environment: 
       GDB_JAVA_OPTS: >-
         -Xmx2g -Xms2g


### PR DESCRIPTION
Trying to use docker compose on an M1 caused this error:

```
=> [internal] load build definition from Dockerfile                                                                                          0.0s
 => => transferring dockerfile: 32B                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                             0.0s
 => => transferring context: 2B                                                                                                               0.0s
 => ERROR [internal] load metadata for docker.io/library/eclipse-temurin:11-jdk-alpine                                                        0.6s
------
 > [internal] load metadata for docker.io/library/eclipse-temurin:11-jdk-alpine:
------
failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: no match for platform in manifest sha256:8368526729a4fa4275807761f51770c505a16c8dcad969609d7644de9dab9367: not found
```

This PR fixes the issue by setting the [platform](https://docs.docker.com/compose/compose-file/compose-file-v2/#platform) parameter.

Furthermore, add a variable in the docker compose config to allow overriding the GraphDB version to install. I used the same name as in the [preload config](https://github.com/Ontotext-AD/graphdb-docker/blob/master/preload/docker-compose.yml#L11) for consistency.