### PR TITLE
GDB-8272-Fix-security-vulnerabilities-in-10.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ENV GRAPHDB_INSTALL_DIR=${GRAPHDB_PARENT_DIR}/dist
 WORKDIR /tmp
 
 RUN apk add --no-cache bash curl util-linux procps net-tools busybox-extras wget less libc6-compat && \
+    apk upgrade libssl3 libcrypto3 && \
     curl -fsSL "https://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb/${version}/graphdb-${version}-dist.zip" > \
     graphdb-${version}.zip && \
     bash -c 'md5sum -c - <<<"$(curl -fsSL https://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb/${version}/graphdb-${version}-dist.zip.md5)  graphdb-${version}.zip"' && \


### PR DESCRIPTION
As there is currently no base image that fixes the vulnerability with the libssl3 and libcrypto3 versions, temporary adding an update for them in our Dockerfile