### PR TITLE
Update docker file to address vulnerabilities in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV GRAPHDB_INSTALL_DIR=${GRAPHDB_PARENT_DIR}/dist
 WORKDIR /tmp
 
 RUN apk add --no-cache bash curl util-linux procps net-tools busybox-extras wget less gcompat && \
-    apk upgrade libssl3 libcrypto3 libexpat && \
+    apk upgrade libssl3 libcrypto3 busybox && \
     curl -fsSL "https://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb/${version}/graphdb-${version}-dist.zip" > \
     graphdb-${version}.zip && \
     bash -c 'md5sum -c - <<<"$(curl -fsSL https://maven.ontotext.com/repository/owlim-releases/com/ontotext/graphdb/graphdb/${version}/graphdb-${version}-dist.zip.md5)  graphdb-${version}.zip"' && \


### PR DESCRIPTION
Update busybox addressing CVE-2023-42363 and CVE-2023-42366 in busybox, busybox-binsh and ssl_client

Update libssl3 addressing CVE-2024-4603 and CVE-2024-2511

Update libcrypto3 addressing CVE-2024-4603 and CVE-2024-2511

Removed update of libexpat as the base image already uses updated version